### PR TITLE
Update close button functionality in create box component

### DIFF
--- a/BFF/src/app/boxlist/(create)/createbox.component.html
+++ b/BFF/src/app/boxlist/(create)/createbox.component.html
@@ -1,7 +1,7 @@
 <dialog id="create_box" class="modal">
   <div class="modal-box">
     <form method="dialog" (ngSubmit)="onCreateBox($event)" [formGroup]="boxForm">
-      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+      <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" onclick="create_box.close()">✕</button>
 
       <div class="flex flex-col">
         <div class="prose">


### PR DESCRIPTION
This commit fixes the behavior of the close button in the create box modal. Previously, the button had no explicit type defined and no click handler attached. With this commit, the button now has a type of 'button' set explicitly and a click handler that closes the modal window. This change ensures the modal closes correctly when the close button is clicked.