### PR TITLE
Add shipping status change functionality in orders list

### DIFF
--- a/BFF/src/app/interfaces/order-interface.ts
+++ b/BFF/src/app/interfaces/order-interface.ts
@@ -20,3 +20,7 @@ export enum ShippingStatus {
   Preparing = 'Preparing',
   Shipped = 'Shipped'
 }
+
+export interface ShippingStatusDto {
+  shippingStatus: ShippingStatus;
+}

--- a/BFF/src/app/orders/list/list.component.html
+++ b/BFF/src/app/orders/list/list.component.html
@@ -18,6 +18,15 @@
         <td> {{order.shippingStatus}} </td>
         <td> {{Object.keys(order.boxes).length}} </td>
         <td class="text-right">
+          <div class="dropdown dropdown-end">
+            <label tabindex="0" class="btn m-1">Change shipping status</label>
+            <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
+              <li><button (click)="changeStatus(order.id, ShippingStatus.Received)">{{ShippingStatus.Received}}</button></li>
+              <li><button (click)="changeStatus(order.id, ShippingStatus.Preparing)">{{ShippingStatus.Preparing}}</button></li>
+              <li><button (click)="changeStatus(order.id, ShippingStatus.Shipped)">{{ShippingStatus.Shipped}}</button></li>
+            </ul>
+          </div>
+
           <div class="join hidden">
             <button class="btn btn-ghost rounded-md join-item">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">

--- a/BFF/src/app/orders/list/list.component.ts
+++ b/BFF/src/app/orders/list/list.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {OrderService} from "../../services/order-service";
+import {ShippingStatus} from "../../interfaces/order-interface";
 
 @Component({
   selector: 'app-order-list',
@@ -11,4 +12,11 @@ export class ListComponent {
   }
 
   protected readonly Object = Object;
+  protected readonly ShippingStatus = ShippingStatus;
+
+  changeStatus(id: string, status: ShippingStatus) {
+    this.orderService.updateStatus(id, {shippingStatus: status}).then(r => {
+      this.orderService.get();
+    });
+  }
 }

--- a/BFF/src/app/services/order-service.ts
+++ b/BFF/src/app/services/order-service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {firstValueFrom, Observable} from 'rxjs';
 import {BoxCreateDto, BoxUpdateDto} from "../interfaces/box-inteface";
-import {Order, OrderCreateDto, ShippingStatus} from "../interfaces/order-interface";
+import {Order, OrderCreateDto, ShippingStatus, ShippingStatusDto} from "../interfaces/order-interface";
 
 @Injectable({
   providedIn: 'root'
@@ -17,49 +17,10 @@ export class OrderService {
   async get() {
     const call = this.http.get<Order[]>(`${this.apiUrl}`);
     this.orders = await firstValueFrom<Order[]>(call);
-    console.log(this.orders);
   }
 
-  async getlocal(){
-    this.orders = [
-      {
-        id: 'b33faf20-114c-4f8d-bb56-47c1eeca77c1',
-        shippingStatus: ShippingStatus.Received,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        boxes: {
-          "1": 10,
-        },
-        customer: {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'john.doe@example.com',
-          address: { houseNumber: 23,houseNumberAddition:'', streetName: 'Main St', city: 'Hometown', country: 'CA', postalCode: '12345' },
-          phoneNumber: '123-456-7890'
-        }
-      },
-      {
-        id: 'a12bc34d-e56f-78g9-0hi1-234j567k890l',
-        shippingStatus: ShippingStatus.Shipped,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        boxes: {
-          "2": 5,
-          "3": 2,
-        },
-        customer: {
-          firstName: 'Jane',
-          lastName: 'Smith',
-          email: 'jane.smith@example.com',
-          address: { houseNumber: 45,houseNumberAddition:'', streetName: 'Market St', city: 'Newtown', country: 'US', postalCode: '67890' },
-          phoneNumber: '098-765-4321'
-        }
-      }
-    ];
-  }
-
-  public getbyId(id: string): Observable<Order> {
-    return this.http.get<Order>(`${this.apiUrl}/${id}`);
+  public getbyId(id: string) {
+    return firstValueFrom(this.http.get<Order>(`${this.apiUrl}/${id}`));
   }
 
   public create(orderCreateDto: OrderCreateDto) {
@@ -70,7 +31,11 @@ export class OrderService {
     return firstValueFrom(this.http.put<Order>(`${this.apiUrl}/${id}`, boxUpdateDto));
   }
 
-  public delete(id: string) : Observable<any> {
-    return this.http.delete(`${this.apiUrl}/${id}`);
+  public delete(id: string) {
+    return firstValueFrom(this.http.delete(`${this.apiUrl}/${id}`));
+  }
+
+  public updateStatus(id: string, status: ShippingStatusDto) {
+    return firstValueFrom(this.http.patch<Order>(`${this.apiUrl}/${id}`, status));
   }
 }


### PR DESCRIPTION
A dropdown menu has been added to each order in the orders list that allows the user to update the shipping status of the order. This was done to provide a straightforward way for users to manage order statuses. The necessary methods for updating the shipping status have been included in the order service, and the ShippingStatus interface has also been adjusted to reflect the new changes.