### PR TITLE
Implement pagination for box list

### DIFF
--- a/BFF/src/app/boxlist/boxlist.component.ts
+++ b/BFF/src/app/boxlist/boxlist.component.ts
@@ -10,7 +10,7 @@ export class BoxListComponent {
   constructor(private boxService: BoxService) {
   }
   onSearchClick(value: string) {
-    this.boxService.get(value);
+    this.boxService.get(1, value);
     console.log(value); // For testing purpose
   }
 }

--- a/BFF/src/app/boxlist/list/list.component.html
+++ b/BFF/src/app/boxlist/list/list.component.html
@@ -56,3 +56,14 @@
   </tr>
   </tfoot>
 </table>
+
+<div class="w-full text-center">
+  <div class="join m-auto">
+    <button *ngFor="let button of buttons; let index = index"
+            class="join-item btn"
+            [ngClass]="{'btn-active': index === currentPage}"
+            (click)="getNextPage(index)">
+      {{index + 1}}
+    </button>
+  </div>
+</div>

--- a/BFF/src/app/boxlist/list/list.component.ts
+++ b/BFF/src/app/boxlist/list/list.component.ts
@@ -1,14 +1,35 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {BoxService} from "../../services/box-service";
-import {BoxUpdateDto} from "../../interfaces/box-inteface";
+import {BoxUpdateDto, PaginatedBoxList} from "../../interfaces/box-inteface";
 
 @Component({
   selector: 'app-box-list',
   templateUrl: './list.component.html',
 })
-export class ListComponent {
+export class ListComponent implements OnInit {
+
+  currentPage: number = 0;
+  // @ts-ignore
+  buttons: any[];
 
   constructor(public boxService: BoxService) {
+  }
+
+  async ngOnInit() {
+    let result = await this.boxService.get(this.currentPage+1,"10", "");
+    this.buttons = Array(result.pageCount).fill(null);
+    console.log(result.pageCount);
+  }
+  async getNextPage(page: number) {
+    this.currentPage = page;
+    try {
+      let result = await this.boxService.get(this.currentPage + 1,"10", "");
+      console.log(result);
+      // Update your component state based on the result here
+    } catch (err) {
+      // Handle errors here.
+      console.log(err);
+    }
   }
 
   async deleteBox(boxId: string) {

--- a/BFF/src/app/interfaces/box-inteface.ts
+++ b/BFF/src/app/interfaces/box-inteface.ts
@@ -1,5 +1,11 @@
 import {Dimensions, DimensionsDto} from "./dimension-interface";
 
+
+export interface PaginatedBoxList {
+  boxes: Box[];
+  pageCount: number;
+}
+
 export interface Box {
   id: string; // Guids are represented as strings in Typescript
   weight: number; // float numbers are represented as number type in TypeScript

--- a/BFF/src/app/orders/(create)/createorder.component.ts
+++ b/BFF/src/app/orders/(create)/createorder.component.ts
@@ -37,7 +37,7 @@ export class CreateorderComponent {
   });
 
   constructor(public boxService: BoxService, public orderService: OrderService) {
-    this.boxService.get().then(boxes => this.boxes = this.boxService.boxes);
+    this.boxService.get(1).then(boxes => this.boxes = this.boxService.boxes);
     this.order = {
       boxes: {},
       customer: { simpsonImgUrl:"" }

--- a/BFF/src/app/services/box-service.ts
+++ b/BFF/src/app/services/box-service.ts
@@ -1,22 +1,28 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import {firstValueFrom, Observable} from 'rxjs';
-import {Box, BoxCreateDto, BoxUpdateDto} from "../interfaces/box-inteface";
+import {Box, BoxCreateDto, BoxUpdateDto, PaginatedBoxList} from "../interfaces/box-inteface";
 
 @Injectable({
   providedIn: 'root'
 })
 export class BoxService {
   boxes: Box[] = [];
+  pageSize: string = "10";
+  public pageCount?: number;
+
   private apiUrl = 'http://localhost:5133/box';
 
   constructor(private http: HttpClient) {
-    this.get();
+    this.get(1,this.pageSize);
   }
 
-  async get(searchTerm?: string) {
-    const call = this.http.get<Box[]>(`${this.apiUrl}?boxesPerPage=1000&searchTerm=${searchTerm ?? ''}`);
-    this.boxes = await firstValueFrom<Box[]>(call);
+  async get(currentPage:number, count?: string | "10",  searchTerm?: string) {
+    const call = this.http.get<PaginatedBoxList>(`${this.apiUrl}?currentPage=${currentPage}&boxesPerPage=${count}&searchTerm=${searchTerm ?? ''}`);
+    let result = await firstValueFrom(call);
+    this.boxes = result.boxes;
+    this.pageCount = result.pageCount;
+    return result;
   }
 
   public getbyId(id: string) {


### PR DESCRIPTION
Added pagination for the box list to enhance user experience and performance. Now, instead of fetching all boxes at once, we fetch only a predefined number of boxes according to the current page. Various changes have been made: the 'box-inteface' has been extended to include 'PaginatedBoxList', the 'BoxService' method 'get' receives now the 'currentPage' and 'count' as parameters. The 'ListComponent' implements 'OnInit' and has two new methods namely 'ngOnInit' and 'getNextPage'. In 'BoxlistComponent', the 'onSearchClick' calls 'BoxService.get' with '1' as the first argument. A section for page control buttons has been added to 'list.component.html'.